### PR TITLE
Upgrade i2c-bus to latest and fix deprecated Buffer construction

### DIFF
--- a/ina219.js
+++ b/ina219.js
@@ -151,7 +151,7 @@ Ina219.prototype.enableLogging  = function (enable) {
   */
 Ina219.prototype.writeRegister  = function (register, value, callback) {
 
-	var bytes = new Buffer(2);
+	var bytes = Buffer.alloc(2);
 
 	bytes[0] = (value >> 8) & 0xFF;
 	bytes[1] = value & 0xFF
@@ -167,7 +167,7 @@ Ina219.prototype.writeRegister  = function (register, value, callback) {
   */
 Ina219.prototype.readRegister  = function (register, callback) {
 
-	var res = new Buffer(2);
+	var res = Buffer.alloc(2);
 	
 	this.wire.readI2cBlockSync(this.address, register, 2, res);
 	

--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
   },
   "license": "MIT",
   "dependencies": {
-    "i2c-bus":"^1.1.1"
+    "i2c-bus": "^4.0.10"
   },
   "keywords": [
-  "raspberry",
-  "pi",
-  "adafruit",
-  "voltage",
-  "current",
-  "monitor",
-  "ina219",
-  "i2c-bus",
-  "i2c"
-],
+    "raspberry",
+    "pi",
+    "adafruit",
+    "voltage",
+    "current",
+    "monitor",
+    "ina219",
+    "i2c-bus",
+    "i2c"
+  ],
   "engine": "node >= 0.12.0"
 }


### PR DESCRIPTION
Hi, thanks for this library. It seems to work perfectly!

I only noted a few problems when installing it on my Raspberry Pi. The older i2c-bus version did not seem to install correctly, but the most recent version does.

Also there were a few warnings on deprecated Buffer methods I fixed.

Hopefully you can accept this merge request, then I can close my own fork of the repo.